### PR TITLE
Add ability to define distance step increments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # gcode Retraction Changer
+
 **Don't forget to star the repository if you think the application is useful. This will help others finding it as well.**
 
 Changes retraction distance and speed from a specific layer gradually, because Cura is unable to do so.
@@ -10,6 +11,7 @@ https://www.thingiverse.com/thing:2450004
 Tested only on Ender 3 and Cura 4.6.1 with my own understanding of `gcode` syntax.
 
 # Prerequisites
+
 Make sure you calibrate your extruder by following one of these tutorials!
 
 https://www.youtube.com/watch?v=xzQjtWhg9VE
@@ -17,29 +19,41 @@ https://www.youtube.com/watch?v=xzQjtWhg9VE
 https://www.youtube.com/watch?v=3yIebnVjADM
 
 # Running the code
-Changing retraction distance, starting with 0 with one step in every 25 layer
+
+Changing retraction distance, starting with 0 with and defaulting to an increase of 1.0mm in every 25 layers
+
 ```shell script
 python ./main.py -f GCODE_FILE_NAME -m distance -l 25 -d 0
 ```
 
+Changing retraction distance with a defined step distance, starting with 0 and increasing by 0.5mm in every 25 layers
+
+```shell script
+python ./main.py -f GCODE_FILE_NAME -m distance -l 25 -d 0 -ds 0.5
+```
+
 Changing retraction speed from 25mm/s by 5mm/s in every 25 layer
+
 ```shell script
 python ./main.py -f GCODE_FILE_NAME -m speed -l 25 -s 1500 -t 300
 ```
 
 Specify the layer height you would like to use for changing the retraction distance in the second parameter.
-For instance of you use 0.2 layer height setting the value to 25 will result as retraction setting change in every 25 * 0.2 = 5mm
+For instance of you use 0.2 layer height setting the value to 25 will result as retraction setting change in every 25 \* 0.2 = 5mm
 
 Specify the initial retraction value. To start with no retraction at all, set this to 0.
 
 # Results
+
 The modified `.gcode` file will be named as `GCODE_FILE_NAME.gcode.mod`. Make sure you compare this with the original.
 Also, make sure you're observing the printer all the time during the execution!
 I TAKE ABSOLUTELY NO WARRANTY FOR RUINING YOUR PRINTER!
 
 # Example
+
 Let's say I want to do a test with the initial retraction distance of 0 and chagne it on every 5mm.
 My layer height is 0.2, so I run the following command:
+
 ```shell script
 python main.py -f tests/CE3_stringing.gcode -m distance -l 25 -d 0
 ```
@@ -74,16 +88,20 @@ These are the lines I've identified as retraction commands in the `.gcode`
 ![retraction_diff](images/retraction_change.png)
 
 # gcode In Action
+
 After running the `.gcode` file in my Ender 3 I realized that the ideal setting is either 2 or 3mm within just 15 minutes!!!
 
 ![stringing](images/IMG_20200729_165354.jpg)
 
 ## Changing retraction speed
+
 After figuring out the ideal retraction distance you can even change the retraction speed for a given `.gcode`.
-I've configured the initial retraction speed of 25mm/s and added 5mm/s increase in every 25 layer. 
+I've configured the initial retraction speed of 25mm/s and added 5mm/s increase in every 25 layer.
+
 ```shell script
 python ./main.py -m speed -f tests/CE3_stringing_2mm_at_45mms_original.gcode -l 25 -s 1500 -t 300
 ```
+
 The results showed that everything above 30mm/s should be fine.
 
 ![stringing](images/IMG_20200730_125529.jpg)

--- a/main.py
+++ b/main.py
@@ -18,6 +18,9 @@ def init_argparse():
     parser.add_argument('-d', '--initial_retraction_distance', type=int,
                     help="defines the initial retraction distance")
 
+    parser.add_argument('-ds', '--retraction_distance_step', type=float, default=1.0,
+                    help="defines the retraction speed step")
+
     parser.add_argument('-s', '--initial_retraction_speed', type=int,
                     help="defines the initial retraction speed")
 
@@ -37,6 +40,7 @@ def main():
     if 'distance' == args.mode:
         change_retraction_distance(gcode_source=gcode_source, gcode_target=gcode_target,
                                    initial_retraction_distance=args.initial_retraction_distance,
+                                   retraction_distance_step=args.retraction_distance_step,
                                    layer_distance=args.layer_step)
 
     elif 'speed' == args.mode:
@@ -87,6 +91,7 @@ def change_retraction_speed(gcode_source=None,
 def change_retraction_distance(gcode_source=None,
                                gcode_target=None,
                                initial_retraction_distance=None,
+                               retraction_distance_step=None,
                                layer_distance=None):
     """
     Changing retraction distance for a specific source file. User has to define the initial distance
@@ -103,7 +108,7 @@ def change_retraction_distance(gcode_source=None,
             log_layer_line(current_layer_at)
             # We increment retraction distance if required
             if not_initial_layer(current_layer_at) and have_to_change_variable_at_layer(current_layer_at, layer_distance):
-                current_retraction_distance_at += 1
+                current_retraction_distance_at += retraction_distance_step
 
         if current_layer_at is not None and currently_extruder_at is not None:
             # Changing the retraction setting derived from the original


### PR DESCRIPTION
I found your script exactly what I've been looking for, however I have modified my printer with direct drive.  Since direct drive system retractions have a different range (0.5-2.0) than Bowden systems, I had a need to be able to adjust the distance step increments down from `1`.  This PR adds that ability, but leaves the default value at `1.0`, which should leave the script functioning as it was before my changes if the `-ds` option is omitted.